### PR TITLE
chore: rename the repo name references

### DIFF
--- a/anthos-baremetal-edge-deployment/README.md
+++ b/anthos-baremetal-edge-deployment/README.md
@@ -62,10 +62,10 @@ The following quick start guide will take approximately **55-60 minutes** to com
 
 ```sh
 # once you have forked this repository, clone it to your local machine
-git clone https://github.com/<YOUR_GITHUB_USERNAME>/anthos-edge-usecases
+git clone https://github.com/<YOUR_GITHUB_USERNAME>/point-of-sale
 
 # move into the root of the infrastructure setup directory
-cd anthos-edge-usecases/anthos-baremetal-edge-deployment
+cd point-of-sale/anthos-baremetal-edge-deployment
 ```
 
 
@@ -84,7 +84,7 @@ export PROXY_PORT="8082"
 # should be a multiple of 3 since N/3 clusters are created with each having 3 nodes
 export MACHINE_COUNT="3"
 
-# fork of this repository: https://github.com/GoogleCloudPlatform/anthos-edge-usecases
+# fork of this repository: https://github.com/GoogleCloudPlatform/point-of-sale
 export ROOT_REPO_URL="<LINK_TO_YOUR_FORK_OF_THIS_REPO>"
 
 # this is the username used to authenticate to your fork of this repository

--- a/anthos-baremetal-edge-deployment/inventory/group_vars/all.yaml
+++ b/anthos-baremetal-edge-deployment/inventory/group_vars/all.yaml
@@ -21,7 +21,7 @@
 ####
 #### Anthos Config Management
 ####
-acm_root_repo: "{{ lookup('env', 'ROOT_REPO_URL') | default('https://github.com/GoogleCloudPlatform/anthos-edge-usecases', True) }}"
+acm_root_repo: "{{ lookup('env', 'ROOT_REPO_URL') | default('https://github.com/GoogleCloudPlatform/point-of-sale', True) }}"
 
 
 #######


### PR DESCRIPTION
# What?

- We are renaming the repo to `point-of-sale` from `anthos-edge-usecases`
- So we need to have this PR ready for merge as soon as we do the renaming
- This will not be merged until we do the rename 