### PR TITLE
cleanup: update distroless image 

### DIFF
--- a/point-of-sale-app/pom.xml
+++ b/point-of-sale-app/pom.xml
@@ -113,7 +113,7 @@
           <version>${jib-maven.plugin.version}</version>
           <configuration>
             <from>
-              <image>gcr.io/distroless/java:11</image>
+              <image>gcr.io/distroless/java11-debian11</image>
             </from>
           </configuration>
         </plugin>


### PR DESCRIPTION
Based on [this doc from `Jib`](https://github.com/GoogleContainerTools/jib/blob/master/docs/default_base_image.md#migration-from-pre-30):
> However, even when you decide to keep using Distroless, at least we strongly recommend gcr.io/distroless/java-debian10:11, because, as of Apr 2021, gcr.io/distroless/java:{8,11} is based on Debian 9 that reached end-of-life. (Note gcr.io/distroless/java-debian10 doesn't have :8.)

And when looking at the [`distroless` repo](https://github.com/GoogleContainerTools/distroless/tree/main/java), there is even this [new update/recommendation since 2021-12](https://github.com/GoogleContainerTools/distroless/commit/d4ef1e32e0bdbf694f20b69f71766d72b1adc667#diff-0c997611c3c5fb9fa0641cb88e5aaa485b5fbc7293676fc28afab310dd430812) hence this update with `gcr.io/distroless/java11-debian11`.