### PR TITLE
cleanup: Remove default image prefix in `skaffold.yaml`

### DIFF
--- a/point-of-sale-app/README.md
+++ b/point-of-sale-app/README.md
@@ -2,7 +2,7 @@
 
 1. Use skaffold to deploy the application
 ```bash
-skaffold run
+skaffold run --default-repo=us-docker.pkg.dev/anthos-dpe-abm-edge-pos/abm-edge-pos-images
 ```
 
 2. Get the external IP of the `api-server`

--- a/point-of-sale-app/skaffold.yaml
+++ b/point-of-sale-app/skaffold.yaml
@@ -18,13 +18,13 @@ metadata:
   name: backend # module defining backend services
 build:
   artifacts:
-  - image: us-docker.pkg.dev/anthos-dpe-abm-edge-pos/abm-edge-pos-images/api-server
+  - image: api-server
     jib:
       project: api-server
-  - image: us-docker.pkg.dev/anthos-dpe-abm-edge-pos/abm-edge-pos-images/inventory
+  - image: inventory
     jib:
       project: inventory
-  - image: us-docker.pkg.dev/anthos-dpe-abm-edge-pos/abm-edge-pos-images/payments
+  - image: payments
     jib:
       project: payments
   tagPolicy:


### PR DESCRIPTION
The goal of this PR is to improve the usability of examples for Skaffold users. Removing the `us-docker.pkg.dev/anthos-dpe-abm-edge-pos/abm-edge-pos-images/` image prefix will allow to run examples with just the `--default-repo` option and without having to modify the `skaffold.yaml`.

Took example from this: https://github.com/GoogleContainerTools/skaffold/pull/3368