### PR TITLE
cleanup: renovate skip vue major version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,14 @@
     {
       "matchPackageNames": ["npm"],
       "allowedVersions": "<8.2.0"
+    },
+    {
+      "matchPackageNames": ["vue"],
+      "allowedVersions": "<3.0.0"
+    },
+    {
+      "matchPackageNames": ["vuex"],
+      "allowedVersions": "<4.0.0"
     }
   ]
 }


### PR DESCRIPTION
### What?
- Stop renovate from bumping major versions of Vue. 
- Bumping Vue version needs bumping of other dependencies used which can be in conflict
- So we want to do it diligently only when needed.

#### Related PR:
- https://github.com/GoogleCloudPlatform/point-of-sale/pull/74