### PR TITLE
fix: remove incorrect delimiter in skaffold

### DIFF
--- a/point-of-sale-app/skaffold.yaml
+++ b/point-of-sale-app/skaffold.yaml
@@ -42,4 +42,3 @@ deploy:
     - kubernetes-manifests/inventory.yaml
     - kubernetes-manifests/payments.yaml
 # [END anthosbaremetal_point_of_sale_app_skaffold_config_backend]
----


### PR DESCRIPTION
#### What?
- The extra lines at the end `skaffold.yaml` is breaking the skaffold run