### PR TITLE
ci: add cloudbuild config for running on PR close event

### DIFF
--- a/.github/cloudbuild/pos-pr-close.yaml
+++ b/.github/cloudbuild/pos-pr-close.yaml
@@ -22,7 +22,7 @@ steps:
   args:
   - -c
   - |
-      echo "Event [$_PULL_REQUEST_TYPE] for pr-$_PULL_REQUEST_ID"
+      echo "Event [$_PULL_REQUEST_EVENT_TYPE] for pr-$_PULL_REQUEST_ID"
       if [ $_PULL_REQUEST_EVENT_TYPE == 'closed' ]; then
         kubectl delete namespace pr-$_PULL_REQUEST_ID || true
       fi

--- a/.github/cloudbuild/pos-pr-close.yaml
+++ b/.github/cloudbuild/pos-pr-close.yaml
@@ -16,28 +16,18 @@ steps:
 ###########################################################
 # cleanup the namespace and resources
 ###########################################################
-- id: 'create-skaffold-exec-script'
+- id: 'delete-namespace-on-pr-close'
   name: ubuntu
   entrypoint: bash
   args:
   - -c
   - |
-      echo $_PULL_REQUEST_ID
-      echo $_PULL_REQUEST_TYPE
+      echo "Event [$_PULL_REQUEST_TYPE] for pr-$_PULL_REQUEST_ID"
+      if [ $_PULL_REQUEST_EVENT_TYPE == 'closed' ]; then
+        kubectl delete namespace pr-$_PULL_REQUEST_ID || true
+      fi
   waitFor: [ '-' ]
-#- id: 'cleanup-k8s-namespace'
-#  name: 'gcr.io/cloud-builders/kubectl'
-#  dir: '.github/cloudbuild'
-#  env:
-#  - 'CLOUDSDK_COMPUTE_ZONE=$_DEV_CLUSTER_ZONE'
-#  - 'CLOUDSDK_CONTAINER_CLUSTER=$_DEV_CLUSTER'
-#  args: [
-#          'delete',
-#          'namespace',
-#          'pr-$_PR_NUMBER'
-#  ]
 
-timeout: 900s
 logsBucket: 'gs://pos-cloudbuild-logs'
 options:
     logging: GCS_ONLY

--- a/.github/cloudbuild/pos-pr-close.yaml
+++ b/.github/cloudbuild/pos-pr-close.yaml
@@ -1,0 +1,43 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+###########################################################
+# cleanup the namespace and resources
+###########################################################
+- id: 'create-skaffold-exec-script'
+  name: ubuntu
+  entrypoint: bash
+  args:
+  - -c
+  - |
+      echo $_PULL_REQUEST_ID
+      echo $_PULL_REQUEST_TYPE
+  waitFor: [ '-' ]
+#- id: 'cleanup-k8s-namespace'
+#  name: 'gcr.io/cloud-builders/kubectl'
+#  dir: '.github/cloudbuild'
+#  env:
+#  - 'CLOUDSDK_COMPUTE_ZONE=$_DEV_CLUSTER_ZONE'
+#  - 'CLOUDSDK_CONTAINER_CLUSTER=$_DEV_CLUSTER'
+#  args: [
+#          'delete',
+#          'namespace',
+#          'pr-$_PR_NUMBER'
+#  ]
+
+timeout: 900s
+logsBucket: 'gs://pos-cloudbuild-logs'
+options:
+    logging: GCS_ONLY

--- a/.github/cloudbuild/pos-pr-open-to-main.yaml
+++ b/.github/cloudbuild/pos-pr-open-to-main.yaml
@@ -82,6 +82,7 @@ steps:
   - |
     cat <<EOF > /workspace/deploy.sh -
     #!/bin/bash
+    rm -rf ~/.mvn
     gcloud container clusters get-credentials --zone $_DEV_CLUSTER_ZONE $_DEV_CLUSTER
     skaffold run -f=skaffold.yaml --default-repo=us-docker.pkg.dev/$PROJECT_ID/$_POS_IMAGE_REPO --namespace=pr-$_PR_NUMBER --tag=pr-$_PR_NUMBER
     EOF

--- a/.github/cloudbuild/pos-pr-webhook-event.yaml
+++ b/.github/cloudbuild/pos-pr-webhook-event.yaml
@@ -18,6 +18,9 @@ steps:
 ###########################################################
 - id: 'delete-namespace-on-pr-close'
   name: 'gcr.io/cloud-builders/kubectl'
+  env:
+  - 'CLOUDSDK_COMPUTE_ZONE=$_DEV_CLUSTER_ZONE'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=$_DEV_CLUSTER'
   entrypoint: bash
   args:
   - -c

--- a/.github/cloudbuild/pos-pr-webhook-event.yaml
+++ b/.github/cloudbuild/pos-pr-webhook-event.yaml
@@ -23,13 +23,12 @@ steps:
   - -c
   - |
       echo "Event [$_PULL_REQUEST_EVENT_TYPE] for pr-$_PULL_REQUEST_ID"
-      if [ $_PULL_REQUEST_EVENT_TYPE == 'synchronize' ]; then
+      if [ $_PULL_REQUEST_EVENT_TYPE == 'closed' ]; then
         gcloud container clusters get-credentials --zone $_DEV_CLUSTER_ZONE $_DEV_CLUSTER
         kubectl delete namespace pr-$_PULL_REQUEST_ID || true
       else
         echo "Nothing to do since it's not a 'closed' event"
       fi
-  waitFor: [ '-' ]
 
 logsBucket: 'gs://pos-cloudbuild-logs'
 options:

--- a/.github/cloudbuild/pos-pr-webhook-event.yaml
+++ b/.github/cloudbuild/pos-pr-webhook-event.yaml
@@ -23,7 +23,7 @@ steps:
   - -c
   - |
       echo "Event [$_PULL_REQUEST_EVENT_TYPE] for pr-$_PULL_REQUEST_ID"
-      if [ $_PULL_REQUEST_EVENT_TYPE == 'closed' ]; then
+      if [ $_PULL_REQUEST_EVENT_TYPE == 'synchronize' ]; then
         kubectl delete namespace pr-$_PULL_REQUEST_ID || true
       else
         echo "Nothing to do since it's not a 'closed' event"

--- a/.github/cloudbuild/pos-pr-webhook-event.yaml
+++ b/.github/cloudbuild/pos-pr-webhook-event.yaml
@@ -17,7 +17,7 @@ steps:
 # cleanup the namespace and resources
 ###########################################################
 - id: 'delete-namespace-on-pr-close'
-  name: ubuntu
+  name: 'gcr.io/cloud-builders/kubectl'
   entrypoint: bash
   args:
   - -c

--- a/.github/cloudbuild/pos-pr-webhook-event.yaml
+++ b/.github/cloudbuild/pos-pr-webhook-event.yaml
@@ -18,15 +18,13 @@ steps:
 ###########################################################
 - id: 'delete-namespace-on-pr-close'
   name: 'gcr.io/cloud-builders/kubectl'
-  env:
-  - 'CLOUDSDK_COMPUTE_ZONE=$_DEV_CLUSTER_ZONE'
-  - 'CLOUDSDK_CONTAINER_CLUSTER=$_DEV_CLUSTER'
   entrypoint: bash
   args:
   - -c
   - |
       echo "Event [$_PULL_REQUEST_EVENT_TYPE] for pr-$_PULL_REQUEST_ID"
       if [ $_PULL_REQUEST_EVENT_TYPE == 'synchronize' ]; then
+        gcloud container clusters get-credentials --zone $_DEV_CLUSTER_ZONE $_DEV_CLUSTER
         kubectl delete namespace pr-$_PULL_REQUEST_ID || true
       else
         echo "Nothing to do since it's not a 'closed' event"

--- a/.github/cloudbuild/pos-pr-webhook-event.yaml
+++ b/.github/cloudbuild/pos-pr-webhook-event.yaml
@@ -25,6 +25,8 @@ steps:
       echo "Event [$_PULL_REQUEST_EVENT_TYPE] for pr-$_PULL_REQUEST_ID"
       if [ $_PULL_REQUEST_EVENT_TYPE == 'closed' ]; then
         kubectl delete namespace pr-$_PULL_REQUEST_ID || true
+      else
+        echo "Nothing to do since it's not a 'closed' event"
       fi
   waitFor: [ '-' ]
 


### PR DESCRIPTION
### Description
- In this PR a new [webhook event trigger](https://github.com/GoogleCloudPlatform/point-of-sale/settings/hooks) has been introduced in CloudBuild
- The webhook is specific to PullRequest event
- We add a cloudbuild config that checks if the event is of type `closed` (this included merge events as well) and if so then cleans up the PR specific resources in the test cluster