### PR TITLE
improvement: split manifests for dev and release

### DIFF
--- a/point-of-sale-app/k8-manifests/README.md
+++ b/point-of-sale-app/k8-manifests/README.md
@@ -1,0 +1,13 @@
+# Kubernetes manifests
+
+This directory holds the Kubernetes manifest files that can be used to deploy
+the **Point-of-Sale** application. The manifests are seperated into categories
+based on the deployment environment. You will notice multiple directories _(
+e.g. `dev`, `release`)_ that contains the manifest files for the same Kubernetes
+resources with minor differences according to the environment. The manifest
+files for resources that does not change based on the environment are found at
+the root of this _(`k8-manifests`)_ directory.
+
+- **dev:** Contains the manifest definition for the `Deployments` that can be
+  used during local development. The container image definitions (1, 2, 3) in these files
+  are specific to 

--- a/point-of-sale-app/k8-manifests/README.md
+++ b/point-of-sale-app/k8-manifests/README.md
@@ -8,6 +8,43 @@ resources with minor differences according to the environment. The manifest
 files for resources that does not change based on the environment are found at
 the root of this _(`k8-manifests`)_ directory.
 
-- **dev:** Contains the manifest definition for the `Deployments` that can be
-  used during local development. The container image definitions (1, 2, 3) in these files
-  are specific to 
+- [**dev** directory:](dev/) contains the manifest definition for
+  the `Deployments` that can be used during local development. These manifests
+  are specific to the [**skaffold**](https://skaffold.dev/) tool. The container
+  image definitions ([1](dev/api-server.yaml#L34), [2](dev/inventory.yaml#L34)
+  , [3](dev/payments.yaml#L34)) in these files match the images defined in
+  the [**skaffold build context**](/point-of-sale-app/skaffold.yaml#L40-L47)
+  of the `skaffold.yaml` file. This ensures, during the _dev flow_, skaffold can
+  push the images built from the locally available source to some
+  container-image repository _(
+  e.g. [Google Container Registry](https://cloud.google.com/container-registry),
+  [Google Artifact Registry](https://cloud.google.com/artifact-registry))_ and
+  update the manifests to point to those freshly built images.
+
+  > **Note:** These manifests cannot be used with `kubectl` to directly apply to
+  > a cluster since they don't have a fully qualified URI for the
+  > container-images. You must use `skaffold` with the **dev** profile.
+
+  ```shell
+  # Example with Google Container Registry
+  skaffold dev -p dev --default-repo gcr.io/<GOOGLE_CLOUD_PROJECT>
+  
+  # Example with Google Artifact Registry
+  skaffold dev -p dev --default-repo us-docker.pkg.dev/<GOOGLE_CLOUD_PROJECT>/<IMAGE_REPO> 
+  ```
+
+- [**release** directory:](release/) contains the manifests that use the
+  **latest released** images of the `Deployments`. The container image
+  definitions ([1](release/api-server.yaml#L34), [2](release/inventory.yaml#L34)
+  , [3](release/payments.yaml#L34)) in these files are pinned to the most recent
+  release tag. The release container-images are publicly accessible. Thus, these
+  manifests can be directly applied to any cluster using `kubectl`.
+
+  ```shell
+  # Example with kubctl
+  kubectl apply -f ./         # apply the common resources first
+  kubectl apply -f release/   # apply the Deployments next
+  
+  # Example with skaffold
+  skaffold dev -p release     # just point to the release profile
+  ```

--- a/point-of-sale-app/k8-manifests/api-server-lb.yaml
+++ b/point-of-sale-app/k8-manifests/api-server-lb.yaml
@@ -1,0 +1,30 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthosbaremetal_k8_manifests_api_server_lb_service_api_server_lb]
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-server-lb
+spec:
+  type: LoadBalancer
+  selector:
+    app: api-server
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+# [END anthosbaremetal_k8_manifests_api_server_lb_service_api_server_lb]
+---

--- a/point-of-sale-app/k8-manifests/dev/api-server.yaml
+++ b/point-of-sale-app/k8-manifests/dev/api-server.yaml
@@ -1,0 +1,82 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthosbaremetal_k8_manifests_dev_api_server_deployment_api_server]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-server
+spec:
+  selector:
+    matchLabels:
+      app: api-server
+  template:
+    metadata:
+      labels:
+        app: api-server
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: api-server
+        image: api-server
+        env:
+        - name: INVENTORY_EP
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: INVENTORY_EP
+        - name: PAYMENTS_EP
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: PAYMENTS_EP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /api/ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 5
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /api/healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+          timeoutSeconds: 10
+# [END anthosbaremetal_k8_manifests_dev_api_server_deployment_api_server]
+---
+# [START anthosbaremetal_k8_manifests_dev_api_server_service_api_server_svc]
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-server-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: api-server
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END anthosbaremetal_k8_manifests_dev_api_server_service_api_server_svc]

--- a/point-of-sale-app/k8-manifests/dev/inventory.yaml
+++ b/point-of-sale-app/k8-manifests/dev/inventory.yaml
@@ -1,0 +1,87 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthosbaremetal_k8_manifests_dev_inventory_deployment_inventory]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory
+spec:
+  selector:
+    matchLabels:
+      app: inventory
+  template:
+    metadata:
+      labels:
+        app: inventory
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: inventory
+        image: inventory
+        env:
+        - name: CONNECTOR
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: CONNECTOR
+        - name: ACTIVE_ITEM_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: ACTIVE_ITEM_TYPE
+        - name: ITEMS
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: ITEMS
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 5
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+          timeoutSeconds: 10
+# [END anthosbaremetal_k8_manifests_dev_inventory_deployment_inventory]
+---
+# [START anthosbaremetal_k8_manifests_dev_inventory_service_inventory_svc]
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: inventory
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END anthosbaremetal_k8_manifests_dev_inventory_service_inventory_svc]

--- a/point-of-sale-app/k8-manifests/dev/payments.yaml
+++ b/point-of-sale-app/k8-manifests/dev/payments.yaml
@@ -1,0 +1,71 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthosbaremetal_k8_manifests_dev_payments_deployment_payments]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments
+spec:
+  selector:
+    matchLabels:
+      app: payments
+  template:
+    metadata:
+      labels:
+        app: payments
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: payments
+        image: payments
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 5
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+          timeoutSeconds: 10
+# [END anthosbaremetal_k8_manifests_dev_payments_deployment_payments]
+---
+# [START anthosbaremetal_k8_manifests_dev_payments_service_payments_svc]
+apiVersion: v1
+kind: Service
+metadata:
+  name: payments-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: payments
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END anthosbaremetal_k8_manifests_dev_payments_service_payments_svc]

--- a/point-of-sale-app/k8-manifests/release/api-server.yaml
+++ b/point-of-sale-app/k8-manifests/release/api-server.yaml
@@ -1,0 +1,82 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthosbaremetal_k8_manifests_release_api_server_deployment_api_server]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-server
+spec:
+  selector:
+    matchLabels:
+      app: api-server
+  template:
+    metadata:
+      labels:
+        app: api-server
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: api-server
+        image: us-docker.pkg.dev/anthos-dpe-abm-edge-pos/abm-edge-pos-images/api-server
+        env:
+        - name: INVENTORY_EP
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: INVENTORY_EP
+        - name: PAYMENTS_EP
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: PAYMENTS_EP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /api/ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 5
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /api/healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+          timeoutSeconds: 10
+# [END anthosbaremetal_k8_manifests_release_api_server_deployment_api_server]
+---
+# [START anthosbaremetal_k8_manifests_release_api_server_service_api_server_svc]
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-server-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: api-server
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END anthosbaremetal_k8_manifests_release_api_server_service_api_server_svc]

--- a/point-of-sale-app/k8-manifests/release/inventory.yaml
+++ b/point-of-sale-app/k8-manifests/release/inventory.yaml
@@ -1,0 +1,87 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthosbaremetal_k8_manifests_release_inventory_deployment_inventory]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory
+spec:
+  selector:
+    matchLabels:
+      app: inventory
+  template:
+    metadata:
+      labels:
+        app: inventory
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: inventory
+        image: us-docker.pkg.dev/anthos-dpe-abm-edge-pos/abm-edge-pos-images/inventory
+        env:
+        - name: CONNECTOR
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: CONNECTOR
+        - name: ACTIVE_ITEM_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: ACTIVE_ITEM_TYPE
+        - name: ITEMS
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: ITEMS
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 5
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+          timeoutSeconds: 10
+# [END anthosbaremetal_k8_manifests_release_inventory_deployment_inventory]
+---
+# [START anthosbaremetal_k8_manifests_release_inventory_service_inventory_svc]
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: inventory
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END anthosbaremetal_k8_manifests_release_inventory_service_inventory_svc]

--- a/point-of-sale-app/k8-manifests/release/payments.yaml
+++ b/point-of-sale-app/k8-manifests/release/payments.yaml
@@ -1,0 +1,71 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthosbaremetal_k8_manifests_release_payments_deployment_payments]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments
+spec:
+  selector:
+    matchLabels:
+      app: payments
+  template:
+    metadata:
+      labels:
+        app: payments
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: payments
+        image: us-docker.pkg.dev/anthos-dpe-abm-edge-pos/abm-edge-pos-images/payments
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 5
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+          timeoutSeconds: 10
+# [END anthosbaremetal_k8_manifests_release_payments_deployment_payments]
+---
+# [START anthosbaremetal_k8_manifests_release_payments_service_payments_svc]
+apiVersion: v1
+kind: Service
+metadata:
+  name: payments-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: payments
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END anthosbaremetal_k8_manifests_release_payments_service_payments_svc]

--- a/point-of-sale-app/k8-manifests/service-configs.yaml
+++ b/point-of-sale-app/k8-manifests/service-configs.yaml
@@ -1,0 +1,52 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthosbaremetal_k8_manifests_service_configs_configmap_service_configs]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-configs
+data:
+  INVENTORY_EP: "http://inventory-svc:8080"
+  PAYMENTS_EP: "http://payments-svc:8080"
+  CONNECTOR: "IN_MEMORY"
+  ACTIVE_ITEM_TYPE: "burgers"
+  ITEMS: |
+    items:
+      - name: "BigBurger"
+        type: "burgers"
+        price: 5.50
+        imageUrl: "usr/lib/images/bigburger.png"
+        quantity: 200
+        labels: [ "retail", "restaurant", "food" ]
+      - name: "DoubleBurger"
+        type: "burgers"
+        price: 7.20
+        imageUrl: "usr/lib/images/burgers.png"
+        quantity: 200
+        labels: [ "retail", "restaurant", "food" ]
+      - name: "Shirt"
+        type: "textile"
+        price: 15.50
+        imageUrl: "usr/lib/images/shirt.png"
+        quantity: 50
+        labels: [ "retail", "textile", "clothing" ]
+      - name: "Short"
+        type: "textile"
+        price: 17.20
+        imageUrl: "usr/lib/images/short.png"
+        quantity: 20
+        labels: [ "retail", "textile", "clothing" ]
+# [END anthosbaremetal_k8_manifests_service_configs_configmap_service_configs]

--- a/point-of-sale-app/skaffold.yaml
+++ b/point-of-sale-app/skaffold.yaml
@@ -1,4 +1,3 @@
-
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,32 +12,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START anthosbaremetal_point_of_sale_app_skaffold_config_setup]
+apiVersion: skaffold/v2beta21
+kind: Config
+metadata:
+  name: setup # module defining setup steps
+deploy:
+  kubectl:
+    manifests:
+    - k8-manifests/service-configs.yaml
+# [END anthosbaremetal_point_of_sale_app_skaffold_config_setup]
+---
 # [START anthosbaremetal_point_of_sale_app_skaffold_config_backend]
 apiVersion: skaffold/v2beta21
 kind: Config
 metadata:
   name: backend # module defining backend services
-build:
-  artifacts:
-  - image: api-server
-    jib:
-      project: api-server
-  - image: inventory
-    jib:
-      project: inventory
-  - image: payments
-    jib:
-      project: payments
-  tagPolicy:
-    gitCommit: { }
-  local:
-    concurrency: 0
+requires:
+- configs: [ setup ]
 deploy:
   kubectl:
     manifests:
-    - kubernetes-manifests/service-configs.yaml
-    - kubernetes-manifests/api-server.yaml
-    - kubernetes-manifests/api-server-lb.yaml
-    - kubernetes-manifests/inventory.yaml
-    - kubernetes-manifests/payments.yaml
+    - k8-manifests/api-server-lb.yaml
+profiles:
+- name: dev
+  build:
+    artifacts:
+    - image: api-server
+      jib:
+        project: api-server
+    - image: inventory
+      jib:
+        project: inventory
+    - image: payments
+      jib:
+        project: payments
+    tagPolicy:
+      gitCommit: { }
+    local:
+      concurrency: 0
+  deploy:
+    kubectl:
+      manifests:
+      - k8-manifests/dev/api-server.yaml
+      - k8-manifests/dev/inventory.yaml
+      - k8-manifests/dev/payments.yaml
+- name: release
+  activation:
+  - command: dev
+  deploy:
+    kubectl:
+      manifests:
+      - k8-manifests/release/api-server.yaml
+      - k8-manifests/release/inventory.yaml
+      - k8-manifests/release/payments.yaml
 # [END anthosbaremetal_point_of_sale_app_skaffold_config_backend]


### PR DESCRIPTION
## Description:
- The k8s manifests currently point to a concrete image URL for the containers.
- As a result even when doing local development the freshly built images are not deployed to the cluster
- Instead what is deployed is the publicly available image that is referenced in the manifest file
- We need to fix this by providing separate manifest files for dev and release

## Changes:
- Create a new directory for k8 manifests _(The old directory **(kubernetes-manifests)** is kept as is since there can be other documents referencing it. So we will gradually remove it once we have the rest of the setup clean)_
- Place the common manifests in the root directory and move the manifests that need to differ based on environments to their own specific environment directories
- Update the skaffold.yaml file to have profiles for the different scenarios
- Add readme to the new manifests directory explaining each