### PR TITLE
doc: add line breaks and indentation to make the README clear

### DIFF
--- a/point-of-sale-app/k8-manifests/README.md
+++ b/point-of-sale-app/k8-manifests/README.md
@@ -8,43 +8,45 @@ resources with minor differences according to the environment. The manifest
 files for resources that does not change based on the environment are found at
 the root of this _(`k8-manifests`)_ directory.
 
-- [**dev** directory:](dev/) contains the manifest definition for
-  the `Deployments` that can be used during local development. These manifests
-  are specific to the [**skaffold**](https://skaffold.dev/) tool. The container
-  image definitions ([1](dev/api-server.yaml#L34), [2](dev/inventory.yaml#L34)
-  , [3](dev/payments.yaml#L34)) in these files match the images defined in
-  the [**skaffold build context**](/point-of-sale-app/skaffold.yaml#L40-L47)
-  of the `skaffold.yaml` file. This ensures, during the _dev flow_, skaffold can
-  push the images built from the locally available source to some
-  container-image repository _(
-  e.g. [Google Container Registry](https://cloud.google.com/container-registry),
-  [Google Artifact Registry](https://cloud.google.com/artifact-registry))_ and
-  update the manifests to point to those freshly built images.
+- [**dev** directory:](dev/) 
+  - contains the manifest definition for
+    the `Deployments` that can be used during local development. These manifests
+    are specific to the [**skaffold**](https://skaffold.dev/) tool. The container
+    image definitions ([1](dev/api-server.yaml#L34), [2](dev/inventory.yaml#L34)
+    , [3](dev/payments.yaml#L34)) in these files match the images defined in
+    the [**skaffold build context**](/point-of-sale-app/skaffold.yaml#L40-L47)
+    of the `skaffold.yaml` file. This ensures, during the _dev flow_, skaffold can
+    push the images built from the locally available source to some
+    container-image repository _(
+    e.g. [Google Container Registry](https://cloud.google.com/container-registry),
+    [Google Artifact Registry](https://cloud.google.com/artifact-registry))_ and
+    update the manifests to point to those freshly built images.  
+    <br />
+    > **Note:** These manifests cannot be used with `kubectl` to directly apply to
+    > a cluster since they don't have a fully qualified URI for the
+    > container-images. You must use `skaffold` with the **dev** profile.
 
-  > **Note:** These manifests cannot be used with `kubectl` to directly apply to
-  > a cluster since they don't have a fully qualified URI for the
-  > container-images. You must use `skaffold` with the **dev** profile.
-
-  ```shell
-  # Example with Google Container Registry
-  skaffold dev -p dev --default-repo gcr.io/<GOOGLE_CLOUD_PROJECT>
+    ```shell
+    # Example with Google Container Registry
+    skaffold dev -p dev --default-repo gcr.io/<GOOGLE_CLOUD_PROJECT>
   
-  # Example with Google Artifact Registry
-  skaffold dev -p dev --default-repo us-docker.pkg.dev/<GOOGLE_CLOUD_PROJECT>/<IMAGE_REPO> 
-  ```
+    # Example with Google Artifact Registry
+    skaffold dev -p dev --default-repo us-docker.pkg.dev/<GOOGLE_CLOUD_PROJECT>/<IMAGE_REPO> 
+    ```
 
-- [**release** directory:](release/) contains the manifests that use the
-  **latest released** images of the `Deployments`. The container image
-  definitions ([1](release/api-server.yaml#L34), [2](release/inventory.yaml#L34)
-  , [3](release/payments.yaml#L34)) in these files are pinned to the most recent
-  release tag. The release container-images are publicly accessible. Thus, these
-  manifests can be directly applied to any cluster using `kubectl`.
+- [**release** directory:](release/) 
+  - contains the manifests that use the
+    **latest released** images of the `Deployments`. The container image
+    definitions ([1](release/api-server.yaml#L34), [2](release/inventory.yaml#L34)
+    , [3](release/payments.yaml#L34)) in these files are pinned to the most recent
+    release tag. The release container-images are publicly accessible. Thus, these
+    manifests can be directly applied to any cluster using `kubectl`.
 
-  ```shell
-  # Example with kubctl
-  kubectl apply -f ./         # apply the common resources first
-  kubectl apply -f release/   # apply the Deployments next
+    ```shell
+    # Example with kubctl
+    kubectl apply -f ./         # apply the common resources first
+    kubectl apply -f release/   # apply the Deployments next
   
-  # Example with skaffold
-  skaffold dev -p release     # just point to the release profile
-  ```
+    # Example with skaffold
+    skaffold dev -p release     # just point to the release profile
+    ```


### PR DESCRIPTION
ONly change was an extra space and indentations. No text was changed. You can see the [rendered view here](https://github.com/GoogleCloudPlatform/point-of-sale/blob/7fcf971d6695d54eea9db5e16bd41d30ff1d072f/point-of-sale-app/k8-manifests/README.md).