### PR TITLE
cleanup: added renovate bot config changes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,5 +19,20 @@
       "matchPackageNames": ["vuex"],
       "allowedVersions": "<4.0.0"
     }
-  ]
+  ],
+  "prConcurrentLimit":5,
+  "stabilityDays":7,
+  "vulnerabilityAlerts":{
+     "labels":[
+       "type:security"
+     ],
+     "stabilityDays":0
+  },
+  "labels": ["dependencies"],
+  "javascript":{
+    "addLabels": ["lang: javascript"]
+  },
+  "java":{
+    "addLabels": ["lang: java"]
+  }
 }


### PR DESCRIPTION
### Background 
Further fine tunes our renovate bot config setup

### Fixes 
Applying some of the results of the survey. This is an example PR, but it adds stability days, concurrent PR limits, and adds config to bypass that if there is a security vulnerability.
### Change Summary
* Sets prConcurrentLimit to 5, stabilityDays to 7
* Sets both prConcurrentLimit and stabilityDays to 0 if it is a CVE is reported

### Additional Notes
Note: we also have dependabot (which is built into Github) to notify us of security vulnerabilities. 

### Testing Procedure
n/a

### Related PRs or Issues 
n/a
