### PR TITLE
imrpovement: cleanup namespaces

### DIFF
--- a/.github/cloudbuild/pos-deploy-release.yaml
+++ b/.github/cloudbuild/pos-deploy-release.yaml
@@ -33,7 +33,6 @@ steps:
     gcloud container clusters get-credentials --zone $_MAIN_CLUSTER_ZONE $_MAIN_CLUSTER
     kubectl create namespace $_MAIN_NS-db
     kubectl create namespace $_MAIN_NS-inmemory
-    kubectl apply -f /workspace/namespace.yaml
 
     skaffold run -p release -f=skaffold.yaml --namespace=$_MAIN_NS-db
     skaffold run -p release,inmemory -f=skaffold.yaml --namespace=$_MAIN_NS-inmemory

--- a/.github/cloudbuild/pos-pr-webhook-event.yaml
+++ b/.github/cloudbuild/pos-pr-webhook-event.yaml
@@ -31,7 +31,7 @@ steps:
       echo "Event [$_PULL_REQUEST_EVENT_TYPE] for pr-$_PULL_REQUEST_ID"
       if [ $_PULL_REQUEST_EVENT_TYPE == 'closed' ]; then
         gcloud container clusters get-credentials --zone $_DEV_CLUSTER_ZONE $_DEV_CLUSTER
-        kubectl delete namespace pr-$_PULL_REQUEST_ID-db
+        kubectl delete namespace pr-$_PULL_REQUEST_ID-inmemory || true
         kubectl delete namespace pr-$_PULL_REQUEST_ID-db || true
       else
         echo "Nothing to do since it's not a 'closed' event"

--- a/.github/cloudbuild/pos-push-to-main.yaml
+++ b/.github/cloudbuild/pos-push-to-main.yaml
@@ -19,51 +19,54 @@
 
 steps:
   ###########################################################
-  # create namespace yaml for the PR
+  # Deploy the latest from main the staging namespace
   ###########################################################
-- id: 'create-deploy-script'
-  name: ubuntu
+- id: 'deploy-to-k8s-staging'
+  name: 'gcr.io/k8s-skaffold/skaffold:v1.36.0'
   entrypoint: bash
   args:
   - -c
   - |
-    cat <<EOF > /workspace/namespace.yaml -
-    # namespace to deploy the mysql db based deployment
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: $_STAGING_NS-db
-    ---
-    # namespace to deploy the inmemory h2 db based deployment
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: $_STAGING_NS-inmemory
-    EOF
-
-    cat <<EOF > /workspace/deploy.sh -
-    #!/bin/bash
-
     gcloud container clusters get-credentials --zone $_MAIN_CLUSTER_ZONE $_MAIN_CLUSTER
-    kubectl apply -f /workspace/namespace.yaml
+    kubectl create namespace $_STAGING_NS-db
+    kubectl create namespace $_STAGING_NS-inmemory
 
     ./mvnw install
     skaffold run -p dev -f=skaffold.yaml --default-repo=us-docker.pkg.dev/$PROJECT_ID/$_POS_IMAGE_REPO --namespace=$_STAGING_NS-db --tag=$COMMIT_SHA-db
     skaffold run -p dev,inmemory -f=skaffold.yaml --default-repo=us-docker.pkg.dev/$PROJECT_ID/$_POS_IMAGE_REPO --namespace=$_STAGING_NS-inmemory --tag=$COMMIT_SHA-inmemory
-    EOF
-  # indicates that the step need not wait for any other step
-  waitFor: [ '-' ]
+  # waitFor: commented out, so this step waits for all previous steps
 
   ###########################################################
-  # skaffold deploy to kubernetes cluster
+  # Get the namespaces for the most recent PRs
   ###########################################################
-- id: 'deploy-to-k8s'
-  name: 'gcr.io/k8s-skaffold/skaffold:v1.36.0'
-  args: [
-      'bash',
-      '/workspace/deploy.sh'
-  ]
+- id: 'get-namespaces'
+  name: 'us-docker.pkg.dev/point-of-sale-ci/third-party-images/github-cli:mar-22'
+  secretEnv: [ 'GITHUB_TOKEN' ]
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    gh pr list --state closed --limit 10 --json number --jq '.[].number' > /workspace/pr.numbers
+    xargs -n 1 -I '{}' echo pr-{}-db < /workspace/pr.numbers > /workspace/k8.namespaces
+    xargs -n 1 -I '{}' echo pr-{}-inmemory < /workspace/pr.numbers >> /workspace/k8.namespaces
   # waitFor: commented out, so this step waits for all previous steps
+
+  ###########################################################
+  # cleanup old namespaces and resources
+  ###########################################################
+- id: 'delete-namespace-for-closed-prs'
+  name: 'gcr.io/cloud-builders/kubectl'
+  entrypoint: bash
+  args:
+  - -c
+  - |
+      xargs -n 1 -I '{}' kubectl delete namespace {} < /workspace/k8.namespaces || true
+
+availableSecrets:
+  inline:
+  - kmsKeyName: 'projects/$PROJECT_ID/locations/global/keyRings/$_GHTOKEN_KEYRING_NAME/cryptoKeys/$_GHTOKEN_KEY_NAME'
+    envMap:
+      GITHUB_TOKEN: 'CiQAuVI6Z93rj1B1R4yer3G1VzEmW7aHtjATP2jOtyJjkW5qOR8SUQBHWet7zXRDJQTBSvFZuXXsOBIxtvf0VDM610Tjgb5XJY8hbIuBxhsMfDy3+/p2ojVnYmE+Mg9NDg5FGZhlJlB/+PBMCumkbMovTXD582u17A=='
 
 timeout: 1800s
 logsBucket: 'gs://pos-cloudbuild-logs'


### PR DESCRIPTION
### Description
- Post merge, the namespaces and resources created for PRs are not deleted
- This causes a resource limitation
- So we want to make sure when PRs are merged the namespaces created for them are removed

### Changes
- Update the Cloudbuild trigger that runs on pushes to main to check and delete the most recently closed PR namespaces