### PR TITLE
fix: ci to delete the stale namepaces

### DIFF
--- a/.github/cloudbuild/pos-push-to-main.yaml
+++ b/.github/cloudbuild/pos-push-to-main.yaml
@@ -60,6 +60,7 @@ steps:
   args:
   - -c
   - |
+      gcloud container clusters get-credentials --zone $_DEV_CLUSTER_ZONE $_DEV_CLUSTER
       xargs -n 1 -I '{}' kubectl delete namespace {} < /workspace/k8.namespaces || true
 
 availableSecrets:


### PR DESCRIPTION
### Description
- Make sure that we fetch the creds for dev cluster before deleting the namespaces