### PR TITLE
Creating a Build setting for Release using sha256

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -65,7 +65,7 @@ profiles:
       jib:
         project: src/payments
     tagPolicy:
-      sha256: { }
+      gitCommit: { }
     local:
       concurrency: 0
   deploy:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -65,7 +65,7 @@ profiles:
       jib:
         project: src/payments
     tagPolicy:
-      gitCommit: { }
+      sha256: { }
     local:
       concurrency: 0
   deploy:
@@ -75,6 +75,19 @@ profiles:
       - k8-manifests/dev/inventory.yaml
       - k8-manifests/dev/payments.yaml
 - name: release
+  build:
+    artifacts:
+    - image: api-server
+      jib:
+        project: src/api-server
+    - image: inventory
+      jib:
+        project: src/inventory
+    - image: payments
+      jib:
+        project: src/payments
+    tagPolicy:
+      sha256: { }
   deploy:
     kubectl:
       manifests:


### PR DESCRIPTION
Release profile can now build non-development docker images (not using git-commit sha tagging).