### PR TITLE
chore: schedule renovate to run quarterly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,5 +34,9 @@
   },
   "java":{
     "addLabels": ["lang: java"]
-  }
+  },
+  "schedule": [
+    "every 3 months on the first day of the month"
+  ],
+  "timezone": "America/New_York"
 }


### PR DESCRIPTION
#### Description
- Currently renovate runs everyday.
- This opens up updates to library versions that are very new with less 10% adoption
- So I have moved renovate updates to be quarterly (every 3 months)