### PR TITLE
feat: Add auto-approve bot config

### DIFF
--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -1,0 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve
+processes:
+  - "JavaDependency"

--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -15,3 +15,4 @@
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve
 processes:
   - "JavaDependency"
+  - "NodeDependency"


### PR DESCRIPTION
This PR adds config for the auto-approve bot (documented here: https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve) which will approve Renovate PRs that follows very strict conventions and rules (e.g. only patches and minor bumps, all tests must be passing, etc.) Full details of these rules can be found in the previously linked README.