### PR TITLE
build: Add GitHub bot to check license headers

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,35 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file configures a GitHub Bot called "License Header Lint GCF": https://github.com/apps/license-header-lint-gcf
+# The bot runs a GitHub check called "header-check" (inside pull-requests) that warns us about invalid/missing license headers.
+# The schema for this configutation file is documented at https://github.com/googleapis/repo-automation-bots/tree/main/packages/header-checker-lint#header-checker-lint.
+
+allowedCopyrightHolders:
+  - 'Google LLC'
+
+allowedLicenses:
+  - 'Apache-2.0'
+
+# If you want to ignore certain files/folders, use ignoreFiles.
+# ignoreFiles:
+#  - '**/requirements.txt'
+
+# If you want to ignore checking the license year, use ignoreLicenseYear.
+# ignoreLicenseYear: true # Useful when migrating in code licensed at previous years.
+
+sourceFileExtensions:
+  - 'tf'
+  - 'yaml'
+  - 'yml'

--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -30,6 +30,13 @@ allowedLicenses:
 # ignoreLicenseYear: true # Useful when migrating in code licensed at previous years.
 
 sourceFileExtensions:
+  - 'css'
+  - 'java'
+  - 'js'
+  - 'properties'
+  - 'py'
+  - 'sh'
   - 'tf'
+  - 'vue'
   - 'yaml'
   - 'yml'


### PR DESCRIPTION
* This fixes #258.
* [Docs about configuring the bot](https://github.com/googleapis/repo-automation-bots/tree/main/packages/header-checker-lint#header-checker-lint).
* It's unreasonable to expect that we cover all possible file extensions for this repo, so (for now), let's just cover comment-supporting file extensions that appear at least 3 or more times.
* I used [a command](https://stackoverflow.com/a/55317141) to check the frequency of each file extension. Warning: The command misses files without dots (e.g., Dockerfile, Makefile). See output below:

```
  30 java ✅ 
  23 yaml ✅ 
  15 sample
  13 md
  10 png
   9 xml
   8 properties ✅ 
   7 js ✅ 
   5 txt
   5 json
   4 vue ✅ 
   3 yml ✅ 
   2 config
   1 sh ✅ 
   1 rev
   1 py ✅ 
   1 pack
   1 npmrc
   1 idx
   1 ico
   1 gitkeep
   1 gitignore
   1 gif
   1 eslintignore
   1 css ✅ 
   1 cmd
```

* ✅  = included in header-checker-lint.yml
* **How to review:** Notice the `header-check` GitHub check running against this pull-request.
* If you want to see a failing example, see [this kubernetes-engine-samples pull-request](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/964).
