### PR TITLE
chore: Change live demo domain to cymbal.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ If you’re using this app, please ★Star the repository to show your interest!
 </p>
 
 ### Play with it:
-- Latest release: [abm-pos.com](http://abm-pos.com)
-- Build from **main** branch: [staging.abm-pos.com](http://staging.abm-pos.com)
+- Latest release: [point-of-sale.retail.cymbal.dev](http://point-of-sale.retail.cymbal.dev)
+- Build from **main** branch: [staging.point-of-sale.retail.cymbal.dev](http://staging.point-of-sale.retail.cymbal.dev)
 ---
 
 ### Edge computing

--- a/docs/domain-mapping.md
+++ b/docs/domain-mapping.md
@@ -1,12 +1,12 @@
 # Domain mapping for the application
 
-The parent domain for the application is [`abm-pos.com`](http://abm-pos.com)
+The parent domain for the application is [`point-of-sale.retail.cymbal.dev`](http://point-of-sale.retail.cymbal.dev)
 hosted via [Google Domains](https://domains.google/). There are a few
 sub-domains that are used to reach key deployments of the application:
-- Latest release _(using MySQL DB)_: [abm-pos.com](http://abm-pos.com)
-- Latest release _(using H2 Embedded DB)_: [im.abm-pos.com](http://im.abm-pos.com)
-- Build from **main** branch  _(using MySQL DB)_: [staging.abm-pos.com](http://staging.abm-pos.com)
-- Build from **main** branch  _(using H2 Embedded D)_: [im.staging.abm-pos.com](http://im.staging.abm-pos.com)
+- Latest release _(using MySQL DB)_: [point-of-sale.retail.cymbal.dev](http://point-of-sale.retail.cymbal.dev)
+- Latest release _(using H2 Embedded DB)_: [im.point-of-sale.retail.cymbal.dev](http://im.point-of-sale.retail.cymbal.dev)
+- Build from **main** branch  _(using MySQL DB)_: [staging.point-of-sale.retail.cymbal.dev](http://staging.point-of-sale.retail.cymbal.dev)
+- Build from **main** branch  _(using H2 Embedded D)_: [im.staging.point-of-sale.retail.cymbal.dev](http://im.staging.point-of-sale.retail.cymbal.dev)
 
 ### To create a new mapping you have to: _(examples show how the above were created)_
 1. Create a global static IP Address
@@ -30,7 +30,7 @@ sub-domains that are used to reach key deployments of the application:
     #   namespace: release-db
     # spec:
     #   domains:
-    #     - abm-pos.com
+    #     - point-of-sale.retail.cymbal.dev
 
     kubectl apply -f k8-manifests/util/certificates.yaml
     ```

--- a/k8-manifests/util/certificates.yaml
+++ b/k8-manifests/util/certificates.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: release-db
 spec:
   domains:
-    - abm-pos.com
+    - point-of-sale.retail.cymbal.dev
 ---
 # Certificate to be created in the main cluster under the release namespace
 # specific to the H2 Embedded DB based deployment of the application
@@ -32,7 +32,7 @@ metadata:
   namespace: release-inmemory
 spec:
   domains:
-    - im.abm-pos.com
+    - im.point-of-sale.retail.cymbal.dev
 ---
 # Certificate to be created in the main cluster under the staging namespace
 # specific to the MySQL DB based deployment of the application
@@ -43,7 +43,7 @@ metadata:
   namespace: staging-db
 spec:
   domains:
-    - staging.abm-pos.com
+    - staging.point-of-sale.retail.cymbal.dev
 ---
 # Certificate to be created in the main cluster under the staging namespace
 # specific to the H2 Embedded DB based deployment of the application
@@ -54,4 +54,4 @@ metadata:
   namespace: staging-inmemory
 spec:
   domains:
-    - im.staging.abm-pos.com
+    - im.staging.point-of-sale.retail.cymbal.dev


### PR DESCRIPTION
Changes the `abm-pos.com` domain to `cymbal.dev`:
- `point-of-sale.retail.cymbal.dev`
- `im.point-of-sale.retail.cymbal.dev`
- `staging.point-of-sale.retail.cymbal.dev`
- `staging.im.point-of-sale.retail.cymbal.dev`

How to test? Verify that these links work as intended:
- https://point-of-sale.retail.cymbal.dev/
- https://staging.point-of-sale.retail.cymbal.dev/
