### PR TITLE
fix: Comment out CB step to comment on PRs

### DIFF
--- a/.github/cloudbuild/pos-pr-open-to-main.yaml
+++ b/.github/cloudbuild/pos-pr-open-to-main.yaml
@@ -151,10 +151,11 @@ steps:
 #     gh pr comment $_PR_NUMBER --repo GoogleCloudPlatform/point-of-sale --body-file /workspace/gh-comment.txt
 #   waitFor: [ 'get-external-loadbalancer-ip' ]
 
-availableSecrets:
-  secretManager:
-  - versionName: projects/$PROJECT_NUMBER/secrets/$_GHTOKEN_SECRET_NAME/versions/latest
-    env: 'GITHUB_TOKEN'
+# @TODO: Commented until this is resolved: https://github.com/GoogleCloudPlatform/point-of-sale/issues/102
+# availableSecrets:
+#   secretManager:
+#   - versionName: projects/$PROJECT_NUMBER/secrets/$_GHTOKEN_SECRET_NAME/versions/latest
+#     env: 'GITHUB_TOKEN'
 timeout: 1800s
 logsBucket: 'gs://pos-cloudbuild-logs'
 options:


### PR DESCRIPTION
This is commenting out the Cloud Build step that comments on PRs with the staging IP address.

Until https://github.com/GoogleCloudPlatform/point-of-sale/issues/102 is resolved this step will continue failing, which make PRs appear like they're unstable (even if the rest of the tests are passing), e.g.:
![image](https://github.com/GoogleCloudPlatform/point-of-sale/assets/3271352/f465483a-e1ea-44a1-993c-d0c8cca39f41)

In fact, 4 of the open PRs have been stable for multiple days but haven't been merged because they appear unhealthy (due to this issue):
![image](https://github.com/GoogleCloudPlatform/point-of-sale/assets/3271352/3711ae31-9578-45d9-a832-77ea19ce6f35)
