### PR TITLE
bug: update release manifest with MYSQL_HOST env

### DIFF
--- a/k8-manifests/release/inventory.yaml
+++ b/k8-manifests/release/inventory.yaml
@@ -49,6 +49,11 @@ spec:
             configMapKeyRef:
               name: spring-profile
               key: SPRING_PROFILES_ACTIVE
+        - name: MYSQL_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: MYSQL_HOST
         - name: ACTIVE_ITEM_TYPE
           valueFrom:
             configMapKeyRef:

--- a/k8-manifests/release/payments.yaml
+++ b/k8-manifests/release/payments.yaml
@@ -49,6 +49,11 @@ spec:
             configMapKeyRef:
               name: spring-profile
               key: SPRING_PROFILES_ACTIVE
+        - name: MYSQL_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: service-configs
+              key: MYSQL_HOST
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
#### Description

The release manifest doesn't have the env var for MYSQL_HOST that was added to the dev profile in https://github.com/GoogleCloudPlatform/point-of-sale/pull/228